### PR TITLE
Switch to TDEs

### DIFF
--- a/tutorials/TDE_light_curve.md
+++ b/tutorials/TDE_light_curve.md
@@ -252,7 +252,7 @@ print(f"Search radius: {radius_deg}")
 ```
 
 ## 3. Data Access
-To locate data covering the region identified by the TDE target, we begin by performing a cone search in the existing OpenUniverse2024 Roman + Rubin catalogs. This step identifies all known galaxies within the sky area defined by the alert’s position and radius. The resulting catalog provides positions and IDs for each potential host galaxy.  With those coordinates in hand, we then query the corresponding Roman and Rubin image files that overlap this same region, retrieving only the fits files needed for subsequent photometry and light-curve analysis.
+To locate data covering the region identified by the TDE target, we begin by performing a cone search in the existing OpenUniverse2024 Roman + Rubin catalogs. This step identifies all known galaxies within some small radius of the TDE position identified above. The resulting catalog provides positions and IDs for each potential host galaxy.  With those coordinates in hand, we then query the corresponding Roman and Rubin image files that overlap this same region, retrieving only the fits files needed for subsequent photometry and light-curve analysis.
 
 +++
 


### PR DESCRIPTION
Closes #16      
                                                                                                                                                            
Summary         

  Replaces the gravitational wave alert workflow in Section 2 with a TDE (Tidal Disruption Event) lookup from the OpenUniverse2024 transient input catalog.

  Changes

  Section 2 — replaced entirely

  - Removed GW_derive_position() function and its dependencies (json, base64, BytesIO, astropy.table.Table)
  - New code scans SNANA parquet files from the OpenUniverse2024 catalog using pyarrow.fs.S3FileSystem(anonymous=True) to find the first TDE (model_name ==
  "NON1ASED.TDE-BBFIT")
  - Loads the corresponding galaxy info parquet file to extract the host galaxy RA/Dec
  - Sets ra_center, dec_center, radius_deg for use by Section 3 (same interface as before)

  Imports

  - Added pyarrow.fs and pyarrow.parquet as pq
  - Removed from base64 import b64decode, from io import BytesIO, from astropy.table import Table, import json

  Section 1

  - Removed Section 1.1 (summarize_fits_files) as too detailed for this tutorial; kept show_gallery()

  Section 3

  - Removed Section 3.2 (candidate filtering); cone search now returns candidates directly
  - Renumbered Section 3.3 → 3.2
  - Updated prose to reference "TDE target" instead of "GW alert"

  Introduction

  - Updated second paragraph to describe TDEs instead of gravitational waves

I didn't yet rename the tutorial as TDE_light_curve.md because I don't want to mess up @jaladh-singhal  draft PR.  FYI @jaladh-singhal there are now only 2 candidate targets, and I can narrow that down to 1 by choosing the closest one to the search ra and dec, but wasn't sure how that would impact what you are doing.  